### PR TITLE
Log queries at DEBUG, override log level instead

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -129,3 +129,10 @@ logger.index_indexing_slowlog.name = index.indexing.slowlog.index
 logger.index_indexing_slowlog.level = trace
 logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
 logger.index_indexing_slowlog.additivity = false
+
+#################################################
+######## ESQL ###################################
+# Make the logging noisier per default to log executed queries and response times.
+loggers = org.elasticsearch.xpack.esql.action.RestEsqlQueryAction
+logger.org.elasticsearch.xpack.esql.action.RestEsqlQueryAction.name = org.elasticsearch.xpack.esql.action.RestEsqlQueryAction
+logger.org.elasticsearch.xpack.esql.action.RestEsqlQueryAction.level = DEBUG

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -55,7 +55,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
         // Create some kind of query id so that we can correlate the beginning and the end of a query in the logs.
         String queryId = UUIDs.base64UUID();
 
-        LOGGER.info("Beginning execution of ESQL query.\nQuery ID: [{}]\nQuery string: [{}]", queryId, esqlRequest.query());
+        LOGGER.debug("Beginning execution of ESQL query.\nQuery ID: [{}]\nQuery string: [{}]", queryId, esqlRequest.query());
 
         return channel -> {
             RestCancellableNodeClient cancellableClient = new RestCancellableNodeClient(client, request.getHttpChannel());
@@ -84,7 +84,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
         return ActionListener.wrap(r -> {
             listener.onResponse(r);
             // At this point, the StopWatch should already have been stopped, so we log a consistent time.
-            LOGGER.info(
+            LOGGER.debug(
                 "Finished execution of ESQL query.\nQuery ID: [{}]\nQuery string: [{}]\nExecution time: [{}]ms",
                 queryId,
                 esqlQuery,
@@ -94,7 +94,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
             // In case of failure, stop the time manually before sending out the response.
             long timeMillis = responseTimeStopWatch.stop().getMillis();
             listener.onFailure(ex);
-            LOGGER.info(
+            LOGGER.debug(
                 "Failed execution of ESQL query.\nQuery ID: [{}]\nQuery string: [{}]\nExecution time: [{}]ms",
                 queryId,
                 esqlQuery,


### PR DESCRIPTION
Logs for executed ESQL queries should be at DEBUG level. To still make the logging verbose enough for the time being, set the log level for the corresponding class to DEBUG in the log4j2.properties.