### PR TITLE
Add cluster definition to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,16 @@ and then run `curl` in another window like this:
 
     curl -u elastic:password localhost:9200
 
-The definition of this Elasticsearch instance can be found [here](build-tools-internal/src/main/groovy/elasticsearch.run.gradle).
-While developing, you may want to disable security. This can be done as follows:
+To send requests to this Elasticsearch instance, either use the built-in `elastic`
+user and password as above or use the pre-configured `elastic-admin` user:
+
+    curl -u elastic-admin:elastic-password localhost:9200
+
+Security can also be disabled altogether:
 
     ./gradlew :run -Dtests.es.xpack.security.enabled=false
+
+The definition of this Elasticsearch cluster can be found [here](build-tools-internal/src/main/groovy/elasticsearch.run.gradle).
 
 ### Importing the project into IntelliJ IDEA
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,10 @@ and then run `curl` in another window like this:
 
     curl -u elastic:password localhost:9200
 
+The definition of this Elasticsearch instance can be found [here](build-tools-internal/src/main/groovy/elasticsearch.run.gradle).
+While developing, you may want to disable security. This can be done as follows:
+
+    ./gradlew :run -Dtests.es.xpack.security.enabled=false
 
 ### Importing the project into IntelliJ IDEA
 


### PR DESCRIPTION
Our contribution instructions do a good job of quickly explaining how to start a local test cluster.

I think it's useful for new contributors to be find the cluster definition quickly as well. Currently, this requires a good amount of `rgrep`ing.

Additionally, I think devs often like to disable auth when working on a local cluster; why don't we give this setting more visibility :)